### PR TITLE
add minimum constraint on ocplib-endian

### DIFF
--- a/opam
+++ b/opam
@@ -13,7 +13,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "cstruct" "fmt" "result" "jsonm" "ocplib-endian"
+  "cstruct" "fmt" "result" "jsonm"
+  "ocplib-endian" {>="0.7"}
   "alcotest" {test}
 ]
 available: [ ocaml-version >= "4.02.0"]


### PR DESCRIPTION
Since EndianBytes is used, this minimum constraint is required.