### PR TITLE
default build without tests

### DIFF
--- a/opam
+++ b/opam
@@ -8,7 +8,13 @@ doc:          "https://samoht.github.io/depyt/doc"
 license:      "ISC"
 tags:         ["org:mirage"]
 
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" foo:installed]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" foo:installed "--tests" "false"]
+
+build-test:[
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" foo:installed "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
It seems that the default behavior for `ocaml pkg/pkg.ml build` is to set the `--tests` option, and this will lead to the failure of installation due to package `alcotest` not found. Deal with this more explicitly.