### PR TITLE
Depending on result is no longer necessary

### DIFF
--- a/depyt.opam
+++ b/depyt.opam
@@ -16,7 +16,7 @@ build-test: ["dune" "runtest" "-p" name "-j" jobs]
 
 depends: [
   "dune" {build & >= "1.0"}
-  "cstruct" "fmt" "result" "jsonm"
+  "cstruct" "fmt" "jsonm"
   "ocplib-endian" {>="0.7"}
   "alcotest" {test}
 ]

--- a/src/depyt.ml
+++ b/src/depyt.ml
@@ -959,8 +959,6 @@ let pp_json ?minify t ppf x =
 
 module Decode_json = struct
 
-  open Result
-
   type decoder = {
     mutable lexemes: Jsonm.lexeme list;
     d: Jsonm.decoder;


### PR DESCRIPTION
`open Result` causes

```
File "src/depyt.ml", line 1086, characters 21-24:
Error: The type constructor t expects 2 argument(s),
       but is here applied to 1 argument(s)
```

with `result` 1.5, but this project doesn't need `result` anyway, because it requires OCaml >= 4.03.